### PR TITLE
Hotfix - global gitignore missing *.db exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ yarn-error.log*
 vite.config.ts.*
 
 dump.rdb
+
+*.db


### PR DESCRIPTION
##### Description of changes

- [ x] Why (Why did you make this pull request): All server apps would need to add *.db to their respective .gitignore files, so i just put it on the global one.

- [x ] Brief description of the changes: add single line to gitignore
- [ x] Possible breakouts (Possible places where things could break): nowhere, we dont have any other files ending with .db
